### PR TITLE
Super tiny fix non-existing reference to `dbEq`

### DIFF
--- a/functional-programming-lean/src/dependent-types/typed-queries.md
+++ b/functional-programming-lean/src/dependent-types/typed-queries.md
@@ -38,7 +38,7 @@ The solution is to use pattern matching to refine the types of `x` and `y`:
 {{#example_decl Examples/DependentTypes/DB.lean dbEq}}
 ```
 In this version of the function, `x` and `y` have types `Int`, `String`, and `Bool` in the three respective cases, and these types all have `BEq` instances.
-The definition of `dbEq` can be used to define a `BEq` instance for the types that are coded for by `DBType`:
+The definition of `DBType.beq` can be used to define a `BEq` instance for the types that are coded for by `DBType`:
 ```lean
 {{#example_decl Examples/DependentTypes/DB.lean BEqDBType}}
 ```


### PR DESCRIPTION
I am not an expert in Lean so please correct me if I am wrong! IMHO, the book does not talk about the function `dbEq` at all, which can be seen by a quick search of this word in the webpage (though the source code says that - but in the generate book it is named `DBType.beq`).

![image](https://github.com/fzyzcjy/fp-lean/assets/5236035/76bbeb31-1a65-4817-a110-b8a0ddc4c523)
